### PR TITLE
Fix Address object deserialization

### DIFF
--- a/src/main/java/com/blockscore/models/Address.java
+++ b/src/main/java/com/blockscore/models/Address.java
@@ -1,28 +1,29 @@
 package com.blockscore.models;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * The address model.
  */
 public class Address {
-  @NotNull
+  @JsonProperty("address_street1")
   private String street1;
-  
-  @Nullable
+
+  @JsonProperty("address_street2")
   private String street2;
-  
-  @NotNull
+
+  @JsonProperty("address_city")
   private String city;
 
-  @NotNull
+  @JsonProperty("address_subdivision")
   private String subdivision;
 
-  @NotNull
+  @JsonProperty("address_postal_code")
   private String postalCode;
-  
-  @NotNull
+
+  @JsonProperty("address_country_code")
   private String countryCode;
 
 
@@ -40,9 +41,9 @@ public class Address {
    * @param postalCode  the postal (ZIP) code
    * @param countryCode  the country code
    */
-  public Address(@NotNull final String street1, @Nullable final String street2,
-           @NotNull final String city, @NotNull final String subdivision,
-           @NotNull final String postalCode, @NotNull final String countryCode) {
+  public Address(final String street1, final String street2,
+           final String city, final String subdivision,
+           final String postalCode, final String countryCode) {
     this.street1 = street1;
     this.street2 = street2;
     this.city = city;
@@ -58,7 +59,7 @@ public class Address {
    * @return this
    */
   @NotNull
-  public Address setStreet1(@NotNull final String street1) {
+  public Address setStreet1(final String street1) {
     this.street1 = street1;
     return this;
   }
@@ -69,8 +70,8 @@ public class Address {
    * @param street2  Street (Line 2)
    * @return this
    */
-  @Nullable
-  public Address setStreet2(@NotNull final String street2) {
+  @NotNull
+  public Address setStreet2(final String street2) {
     this.street2 = street2;
     return this;
   }
@@ -82,7 +83,7 @@ public class Address {
    * @return this
    */
   @NotNull
-  public Address setCity(@NotNull final String city) {
+  public Address setCity(final String city) {
     this.city = city;
     return this;
   }
@@ -95,7 +96,7 @@ public class Address {
    * @return this
    */
   @NotNull
-  public Address setSubdivision(@NotNull final String subdivision) {
+  public Address setSubdivision(final String subdivision) {
     this.subdivision = subdivision;
     return this;
   }
@@ -107,7 +108,7 @@ public class Address {
    * @return this
    */
   @NotNull
-  public Address setPostalCode(@NotNull final String postalCode) {
+  public Address setPostalCode(final String postalCode) {
     this.postalCode = postalCode;
     return this;
   }
@@ -119,7 +120,7 @@ public class Address {
    * @return this
    */
   @NotNull
-  public Address setCountryCode(@NotNull final String countryCode) {
+  public Address setCountryCode(final String countryCode) {
     this.countryCode = countryCode;
     return this;
   }
@@ -129,7 +130,6 @@ public class Address {
    *
    * @return Line 1 of the address
    */
-  @NotNull
   public String getStreet1() {
     return street1;
   }
@@ -139,7 +139,6 @@ public class Address {
    *
    * @return Line 2 of the address
    */
-  @Nullable
   public String getStreet2() {
     return street2;
   }
@@ -149,7 +148,6 @@ public class Address {
    *
    * @return the address city
    */
-  @NotNull
   public String getCity() {
     return city;
   }
@@ -159,7 +157,6 @@ public class Address {
    *
    * @return the address subdivision
    */
-  @NotNull
   public String getSubdivision() {
     return subdivision;
   }
@@ -169,7 +166,6 @@ public class Address {
    *
    * @return the postal code
    */
-  @NotNull
   public String getPostalCode() {
     return postalCode;
   }
@@ -179,7 +175,6 @@ public class Address {
    *
    * @return the country code
    */
-  @NotNull
   public String getCountryCode() {
     return countryCode;
   }

--- a/src/test/java/com/blockscore/models/CandidateTest.java
+++ b/src/test/java/com/blockscore/models/CandidateTest.java
@@ -6,6 +6,7 @@ import static com.blockscore.models.TestUtils.assertBasicResponseIsValid;
 import static com.blockscore.models.TestUtils.assertBasicResponsesAreEquivalent;
 import static com.blockscore.models.TestUtils.setupBlockscoreApiClient;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
@@ -234,27 +235,7 @@ public class CandidateTest {
   /*------------------*/
 
   private Candidate createTestCandidate() {
-    Address address = (new Address()).setStreet1("1 Infinite Loop")
-                                     .setCity("Harare")
-                                     .setCountryCode("ZW");
-
-    final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
-    Date date = null;
-    try {
-      date = formatter.parse("1980-08-23");
-    } catch (ParseException e) {
-      e.printStackTrace();
-    }
-
-    Candidate.Builder builder = new Candidate.Builder(client);
-    builder.setNote("12341234")
-           .setSsn("001")
-           .setDateOfBirth(date)
-           .setFirstName("John")
-           .setLastName("BredenKamp")
-           .setAddress(address);
-
-    return builder.create();
+    return new Candidate.Builder(client).setFirstName("John").setLastName("BredenKamp").create();
   }
 
   private Candidate createEmptyCandidate() {
@@ -308,12 +289,9 @@ public class CandidateTest {
     assertEquals("US", address.getCountryCode());
   }
 
-  // NOTE: Currently no actual data is being returned for a watchlist search.
-  //       The logic for asserting whether or not the hit is valid will have
-  //       to be modified when sample data is available.
   private void assertHitsAreValid(List<WatchlistHit> hits) {
     assertNotNull(hits);
-    // assertNotEquals(hits.size(), 0); see above note
+    assertNotEquals(hits.size(), 0);
     for (WatchlistHit hit : hits) {
       assertHitIsValid(hit);
     }
@@ -334,7 +312,10 @@ public class CandidateTest {
     assertNotNull(hit.getDateOfBirth());
     assertNull(hit.getSsn());
     assertNotNull(hit.getPassports());
-    assertAddressIsValid(hit.getAddress());
+    assertNotNull(hit.getAddress());
+    assertNotNull(hit.getAddress().getStreet1());
+    assertNotNull(hit.getAddress().getCity());
+    assertNotNull(hit.getAddress().getCountryCode());
     assertNotNull(hit.getRawAddress());
     assertNotNull(hit.getNames());
     assertEquals(hit.getNames().size(), 3);
@@ -343,7 +324,12 @@ public class CandidateTest {
     assertNotNull(hit.getDocuments());
     assertEquals(hit.getDocuments().size(), 4);
     assertNotNull(hit.getAlternateNames());
-    assertNotNull(hit.getAddresses());
+    assertNotEquals(hit.getAddresses().size(), 0);
+    for(Address address : hit.getAddresses()) {
+      assertNotNull(address.getStreet1());
+      assertNotNull(address.getCity());
+      assertNotNull(address.getCountryCode());
+    }
     assertDocumentsAreValid(hit.getDocuments());
   }
 


### PR DESCRIPTION
- Fixes addresses field which previously contained null values for all
  address objects, due to missing @JsonProperty annotations.
- Removes misleading @NotNull annotations which clearly were not true
  for all cases in which Address is used.
- Changes the test candidate to only search for "John Bredenkemp"
  without extra information so that WatchlitHit items will actually be
  returned and the tests prove that addresses can be deserialized
  correctly.
- Adds additional test assertions to prove that the change works
  necessary and to prevent regressions.