### PR TITLE
Upgrade CircleCI to 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/openjdk:8
+    steps:
+      - checkout
+      - run: gradle test


### PR DESCRIPTION
- NOTE: I wasn't sure how to setup gradle caching with CircleCI 2.0, so
  I just said screw it and removed the cache steps we normally have.
  This is rarely run so it probably doesn't make a difference.